### PR TITLE
change the base url for the styles

### DIFF
--- a/lib/configuration/assets.php
+++ b/lib/configuration/assets.php
@@ -25,7 +25,7 @@ function custom_load_custom_style_sheet() {
     $base_url = "https://s3.amazonaws.com/static-getvero-com/staging";
     $suffix   = "css";
   } else {
-    $base_url = "https://d3qxef4rp70elm.cloudfront.net";
+    $base_url = "https://cdn.getvero.com";
     $suffix   = "min.css";
   }
   wp_enqueue_style( 'custom-stylesheet', $base_url."/app.".$suffix, array(), PARENT_THEME_VERSION );


### PR DESCRIPTION
Change the base url to cdn.getvero.com. We made this change recently on app.getvero.com but didn't do it for the marketing site. 

When ad/tracking blockers (ghostery) are running, it seems the css is blocked because it is on the same url prefix as the analytics.js tracking code.

Have tested locally and works. 

@chexton okay with this? 