### PR TITLE
Styling for policies and cookies banner

### DIFF
--- a/pages-shared/static-header.php
+++ b/pages-shared/static-header.php
@@ -49,7 +49,6 @@ function no_content_no_header() {
   do_action( 'genesis_doctype' );
   do_action( 'genesis_title' );
   do_action( 'genesis_meta' );
-  ?><script src="//cdn.optimizely.com/js/2654110240.js"></script><?php
   wp_head(); 
   ?>
   


### PR DESCRIPTION
On this branch we need to style the cookie table that comes from OneTrust and check the OneTrust banner styles.

I've also started testing how the cookies will be dropped.

In particular we need to style the following classes on the cookie policy page:

- `optanon-cookie-policy-group-name` need to be like `h3` tags
- style the tables that OneTrust spits out, perhaps we can make the cookie names a bit like `code` snippets?

---

To use / test this branch locally:

• Run `veropublic` on Docker locally.
• Goto http://localhost:8888/login
• Login and create a new page with the template `Terms and Policies`
• Paste in the HTML view this code: https://gist.github.com/chexton/261c3abfa5fd67515e97373a0fd59344
• Save and rename slug `/cookie-policy`
• Goto the `Genesis > Settings` menu and paste in the following two snippets to setup a test GTM (top one goes in first settings box, latter goes in second):

```
<!-- Google Tag Manager -->
<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
})(window,document,'script','dataLayer','GTM-KBDN343');</script>
<!-- End Google Tag Manager -->
```

```
<!-- Google Tag Manager (noscript) -->
<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KBDN343"
height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
<!-- End Google Tag Manager (noscript) -->
```

- Goto http://localhost:8888/cookie-policy