### PR TITLE
Feature/add resource template

### DIFF
--- a/single-plain-sidebar-hero.php
+++ b/single-plain-sidebar-hero.php
@@ -8,17 +8,21 @@ add_filter( 'genesis_pre_get_option_site_layout', '__genesis_return_sidebar_cont
 
 add_filter( 'body_class', 'metro_add_body_class' );
 function metro_add_body_class( $classes ) {
-   $classes[] = 'left-menu plain-sidebar-hero';
-   return $classes;
+  if(get_field('custom_sidebar')){
+    $classes[] = 'left-menu plain-template';
+  } else {
+    $classes[] = 'plain-template';
+  }
+  return $classes;
 }
 remove_action( 'genesis_sidebar', 'genesis_do_sidebar' );
 remove_action( 'genesis_sidebar_alt', 'genesis_do_sidebar_alt' );
 
-add_action( 'genesis_sidebar', 'generate_sidebar' );
+if(get_field('custom_sidebar')){
+  add_action( 'genesis_sidebar', 'generate_sidebar' );
+}
 function generate_sidebar() {
-  if(get_field('custom_sidebar')){ //if the field is not empty
-    echo '<p>' . get_field('custom_sidebar') . '</p>'; //display it
-  }
+  echo '<p>' . get_field('custom_sidebar') . '</p>'; //display it
 }
 
 add_action( 'genesis_after_header', 'hero', 10, 2  );

--- a/single-plain-sidebar-hero.php
+++ b/single-plain-sidebar-hero.php
@@ -1,0 +1,40 @@
+<?php
+/*
+Template Name: Plain Sidebar + Hero 
+*/
+
+//* Force sidebar-content layout
+add_filter( 'genesis_pre_get_option_site_layout', '__genesis_return_sidebar_content' );
+
+add_filter( 'body_class', 'metro_add_body_class' );
+function metro_add_body_class( $classes ) {
+   $classes[] = 'left-menu plain-sidebar-hero';
+   return $classes;
+}
+
+remove_action( 'genesis_sidebar', 'genesis_do_sidebar' );
+remove_action( 'genesis_sidebar_alt', 'genesis_do_sidebar_alt' );
+
+add_action( 'genesis_sidebar', 'generate_sidebar' );
+function generate_sidebar() {
+  if(get_field('custom_sidebar')){ //if the field is not empty
+    echo '<p>' . get_field('custom_sidebar') . '</p>'; //display it
+  }
+}
+
+add_action( 'genesis_after_header', 'hero', 10, 2  );
+function hero() {
+  $color = get_field('header_color');
+  $image = get_field('image_header');
+  if( !empty($color) ) {
+    echo '<div class="plain-sidebar-hero" style="background-color:' . get_field('header_color') . ';"><div class="site-inner">';
+  } else {
+    echo '<div class="plain-sidebar-hero"><div class="site-inner">';
+  }
+  if( !empty($image) ) {
+    echo '<img src="' . $image['url'] . '" width="100%"/>';
+  }
+  echo '</div></div>';
+}
+
+genesis(); ?>

--- a/single-plain-sidebar-hero.php
+++ b/single-plain-sidebar-hero.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Template Name: Plain Sidebar + Hero 
+Template Name: Plain Sidebar Hero 
 */
 
 //* Force sidebar-content layout
@@ -11,7 +11,6 @@ function metro_add_body_class( $classes ) {
    $classes[] = 'left-menu plain-sidebar-hero';
    return $classes;
 }
-
 remove_action( 'genesis_sidebar', 'genesis_do_sidebar' );
 remove_action( 'genesis_sidebar_alt', 'genesis_do_sidebar_alt' );
 
@@ -25,16 +24,13 @@ function generate_sidebar() {
 add_action( 'genesis_after_header', 'hero', 10, 2  );
 function hero() {
   $color = get_field('header_color');
+  if(empty($color)) {
+    $color = '#ffffff'; // default to white
+  }
   $image = get_field('image_header');
-  if( !empty($color) ) {
-    echo '<div class="plain-sidebar-hero" style="background-color:' . get_field('header_color') . ';"><div class="site-inner">';
-  } else {
-    echo '<div class="plain-sidebar-hero"><div class="site-inner">';
-  }
   if( !empty($image) ) {
-    echo '<img src="' . $image['url'] . '" width="100%"/>';
+    echo '<div class="hero" style="backgorund-color:'. $color . '; background-image: url(' . $image['url'] . ');"></div>';
   }
-  echo '</div></div>';
 }
 
 genesis(); ?>


### PR DESCRIPTION
**Fixes**: https://app.asana.com/0/141406265185791/698542630060331

Added a template that has an optional header and sidebar. This means if we create similar pages in the future we shouldn't need to create a new template for each. Will work best for pages that only link to themselves from the sidebar (it uses a custom field rather than menus).

**Changes**: 
- Added new theme 'plain-sidebar-hero'

- Added custom field for the the hero image and made sure it scales properly depending on size of the window. If there is no image set in the page details (in WP) no image is rendered. Also added a field for the background of the hero image (looks nicer if you set the background color to the base color for when the image hasn't loaded yet). Defaults to white.

- Added custom field for the sidebar. This is a WYSIWYG field that accepts html. Can use this for creating anchor links of if we want something custom in the sidebar. If there is no content there's no sidebar. 

**Review**:
Can you review @chexton? Think Linda is keen to finish early this week. Once you've reviewed I'l copy to live so Linda can create the draft. You can see the page on [Staging](https://veropublic.staging.wpengine.com/?page_id=7709&preview=true) and the configuration in [page config](https://veropublic.staging.wpengine.com/wp-admin/post.php?post=7709&action=edit)

Has a styles PR too: https://github.com/getvero/vero-styles/pull/18