### PR TITLE
add honeypot field to 1 of 2 subscribe forms

### DIFF
--- a/demo-enquiry-form.php
+++ b/demo-enquiry-form.php
@@ -46,6 +46,9 @@
           <input id="phone" name="contact_method" type="radio" value="phone" />
           <label class="method" for="phone">Phone</label>
         </div>
+        <div class="checkbox">
+          <input name="contact_by_fax_only" type="checkbox" value="1" style="display:none !important" tabindex="-1" autocomplete="false" />
+        </div>
       </div>
       <div class="full-width center-text">
         <input type="hidden" name="redirect_on_success" value="https://www.getvero.com/email-marketing-demo/?thanks=yourock">

--- a/demo-enquiry-form.php
+++ b/demo-enquiry-form.php
@@ -20,27 +20,18 @@
         <div class="form-group"><label>Company name: <span>*</span></label><input id="sender_company_name" class="form-control" name="company_name" type="text" /></div>
       </div>
       <div class="half">
-        <div class="form-group"><label>Current number of subscribers:</label><select id="sender_subscribers" class="form-control" name="subscribers">
-          <option value="250000">175,000 - 250,000 subscribers</option>
-          <option value="500000">250,000 - 500,000 subscribers</option>
-          <option value="1000000">500,000 - 1,000,000 subscribers</option>
-          <option value="5000000">1,000,000 - 5,000,000 subscribers</option>
-          <option value="10000000">5,000,000 - 10,000,000 subscribers</option>
-          <option value="more">10,000,000+ subscribers</option></select></div>
-        <div class="form-group"><label>Current number of emails sent monthy:</label><select id="sender_emails" class="form-control" name="monthly_emails">
-          <option value="1000000">400,000 - 1,000,000 emails</option>
-          <option value="1000000">1,000,000 - 5,000,000 emails</option>
-          <option value="10000000">5,000,000 - 10,000,000 emails</option>
-          <option value="50000000">10,000,000 - 50,000,000 emails</option>
-          <option value="more">50,000,000+ emails</option></select></div>
-        <!-- <div class="form-group"><label>Select data region you're interested in:</label><select id="sender_region" class="form-control" name="monthly_emails">
-          <option value="not-important">Not important (agnostic)</option>
-          <option value="usa">North America</option>
-          <option value="eea">Europe (EEA)</option>
-          <option value="au">Australia</option>
-          <option value="china">China</option></select></div> -->
+        <div class="form-group"><label>How many subscribers do you have?</label>
+          <select id="sender_subscribers" class="form-control" name="subscribers">
+            <option value="250000">175,000 - 250,000 subscribers</option>
+            <option value="500000">250,000 - 500,000 subscribers</option>
+            <option value="1000000">500,000 - 1,000,000 subscribers</option>
+            <option value="5000000">1,000,000 - 5,000,000 subscribers</option>
+            <option value="10000000">5,000,000 - 10,000,000 subscribers</option>
+            <option value="more">10,000,000+ subscribers</option>
+          </select>
+        </div>
         <div class="radio-group">
-          <label>Preferred contact method:</label><br>
+          <label>How would you like us to contact you?</label><br>
           <input id="email" checked="checked" name="contact_method" type="radio" value="email" />
           <label class="method" for="email">Email</label>
           <input id="phone" name="contact_method" type="radio" value="phone" />

--- a/demo-enquiry-form.php
+++ b/demo-enquiry-form.php
@@ -1,8 +1,7 @@
 <div id="demo">
   <div class="inner">
     <div id="enquire-intro" class="center-text">
-      <h2>We're here to answer your questions</h2>
-      <p class="medium">Fill out the form below and our sales team will get back to you promptly. We're keen to learn more about your needs and share if and how Vero can work for you.</p>
+      <p class="regular">Fill out the form below and our sales team will get back to you promptly. We're keen to learn more about your needs and share if and how Vero can work for you.</p>
     </div>
     <div id="thanks" class="center-text">
       <h2>Thanks!</h2>
@@ -17,9 +16,9 @@
         <div class="form-group"><label>Name: <span>*</span></label><input id="sender_name" class="form-control" name="name" type="text" autofocus="autofocus" /></div>
         <div class="form-group"><label>Email: <span>*</span></label><input id="sender_email_address" class="form-control" name="email" type="text" /></div>
         <div class="form-group"><label>Phone:</label><input id="sender_phone" class="form-control" name="phone" type="text" /></div>
-        <div class="form-group"><label>Company name: <span>*</span></label><input id="sender_company_name" class="form-control" name="company_name" type="text" /></div>
       </div>
       <div class="half">
+        <div class="form-group"><label>Company name: <span>*</span></label><input id="sender_company_name" class="form-control" name="company_name" type="text" /></div>
         <div class="form-group"><label>How many subscribers do you have?</label>
           <select id="sender_subscribers" class="form-control" name="subscribers">
             <option value="250000">175,000 - 250,000 subscribers</option>
@@ -41,7 +40,7 @@
           <input name="contact_by_fax_only" type="checkbox" value="1" style="display:none !important" tabindex="-1" autocomplete="false" />
         </div>
       </div>
-      <div class="full-width center-text">
+      <div class="full-width top-padding-small center-text">
         <input type="hidden" name="redirect_on_success" value="https://www.getvero.com/email-marketing-demo/?thanks=yourock">
         <input type="submit" value="Get in touch" id="request-demo" class="btn btn-success">
       </div>

--- a/hosted-enquiry-form.php
+++ b/hosted-enquiry-form.php
@@ -40,6 +40,9 @@
           <input id="phone" name="contact_method" type="radio" value="phone" />
           <label class="method" for="phone">Phone</label>
         </div>
+        <div class="checkbox">
+          <input name="contact_by_fax_only" type="checkbox" value="1" style="display:none !important" tabindex="-1" autocomplete="false" />
+        </div>
       </div>
       <div class="full-width center-text">
         <input type="hidden" name="redirect_on_success" value="https://www.getvero.com/email-marketing-demo/?thanks=yourock">

--- a/lib/configuration/posts.php
+++ b/lib/configuration/posts.php
@@ -91,6 +91,7 @@ function add_subscribe_form() {
           <input name='redirect_on_success' type='hidden' value='https://veropublic.wpengine.com/subscribed-to-the-blog/' />
           <input name='user[consent_marketing]' type='hidden' value='true' />
           <input name='user[consent_product_updates]' type='hidden' value='true' />
+          <input name='user[contact_by_fax_only]' type='checkbox' value='1' style='display:none !important' tabindex="-1" autocomplete="false" />
           <input type='submit' value='Subscribe' class="btn btn-success left-margin-tiny"/>
       </form>
       <p class="mini">By subscribing, you consent to let Vero send you messages regarding marketing and product. You can learn more in our <a href="https://www.getvero.com/privacy" target="_blank">Privacy Notice</a>, and you can opt out or change your consent at any time.</p>

--- a/page-pricing.php
+++ b/page-pricing.php
@@ -285,5 +285,4 @@ include 'pages-shared/static-header.php';
   no_content_genesis_footer();
   add_page_tracking_code("PricingPage");
   include("demo-enquiry-form.php");
-  include("hosted-enquiry-form.php");
 ?>


### PR DESCRIPTION
Fixes:
Add a hidden field to the subscribe form that appears at the bottom of each blog post

If a bot selects this hidden checkbox (my understanding is they would) then the property `contact_by_fax_only` will get a value of `1` in Vero. We can then target customers who don't have the property like this https://www.dropbox.com/s/ymaphpj4ihu2dtd/Screen%20Shot%202018-12-10%20at%205.36.20%20pm.png?dl=0 

@chexton does this seem right? Is your understanding that a bots check every available checkbox?

