### PR TITLE
Adds a custom post type called "Tutorials"

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -14,6 +14,7 @@ include_once( 'lib/configuration/footers.php' );
 
 # Add in custom resources and the like
 include_once( 'lib/post_types/guides.php' );          # Guides pages
+include_once( 'lib/post_types/tutorials.php' );          # Tutorials pages
 include_once( 'lib/post_types/release_notes.php' );   # Release Notes
 
 add_action('genesis_setup','genesischild_theme_setup', 15);
@@ -46,6 +47,7 @@ function genesischild_theme_setup() {
   // Add custom types
   add_action( 'init', 'create_release_notes_post_type' );
   add_action( 'init', 'create_guides_post_type' );
+  add_action( 'init', 'create_tutorials_post_type' );
   add_filter( 'pre_get_posts', 'add_custom_types' );
   // add_filter( 'post_link', 'change_url', 10, 3 );
 

--- a/lib/configuration/blog.php
+++ b/lib/configuration/blog.php
@@ -5,7 +5,7 @@ function add_custom_types( $query ) {
 
   if( ( is_post_type_archive('post') || is_home() || is_archive() ) && $query === $wp_the_query && !is_admin() && !is_post_type_archive('release-notes') ) {
     $query->set( 'post_type', array(
-      'post', 'guides'
+      'post', 'guides', 'tutorials'
     ));
 
     $query->set( 'post_parent', 0 );

--- a/lib/configuration/global.php
+++ b/lib/configuration/global.php
@@ -18,7 +18,7 @@ function custom_favicon( $favicon_url ) {
 }
 
 function is_blog() {
-  return ( is_singular('post') || is_singular('guides') || is_home() || is_category() );
+  return ( is_singular('post') || is_singular('guides') || is_singular('tutorials') || is_home() || is_category() );
 }
 
 function is_child_guide() {
@@ -32,6 +32,10 @@ function is_blog_archive() {
 
 function is_blog_post_or_guide() {
   return ( is_singular('post') || is_singular('guides') );
+}
+
+function is_blog_post_or_guide_or_tutorial() {
+  return ( is_singular('post') || is_singular('guides') || is_singular('tutorials') );
 }
 
 function add_body_classes($classes) {

--- a/lib/configuration/posts.php
+++ b/lib/configuration/posts.php
@@ -1,7 +1,7 @@
 <?php
 
 function add_feature_image_to_posts() {
-  if ( is_blog_post_or_guide() ){
+  if ( is_blog_post_or_guide_or_tutorial() ){
     global $post;
 
     $image_id  = get_post_thumbnail_id( $post->ID );
@@ -24,7 +24,7 @@ function move_feature_image() {
 }
 
 function force_full_width_on_posts( $options ) {
-  if( is_blog_post_or_guide() ) {
+  if( is_blog_post_or_guide_or_tutorial() ) {
     $options = 'full-width-content';
     return $options;
   }
@@ -37,8 +37,8 @@ function add_blog_post_back_button() {
     <a href="<?php echo get_permalink($post->post_parent); ?>" class="back-to-blog">Back to Table of Contents</a>
   <?php } else if ( is_singular('release-notes') ) { ?>
     <a href="/release-notes" class="back-to-blog">Back to Release Notes</a>
-  <?php } else if( is_blog_post_or_guide() ){ ?>
-    <a href="/resources" class="back-to-blog">Back to Blog</a>
+  <?php } else if( is_blog_post_or_guide_or_tutorial() ){ ?>
+    <a href="/resources" class="back-to-blog">Back to <em>Resources</em></a>
   <?php }
 }
 

--- a/lib/post_types/tutorials.php
+++ b/lib/post_types/tutorials.php
@@ -1,0 +1,23 @@
+<?php
+
+function create_tutorials_post_type() {
+  $labels = array(
+    'name' => __( 'Tutorials' ),
+    'singular_name' => __( 'Tutorial' )
+  );
+
+  $args = array(
+    'labels' => $labels,
+    'public' => true,
+    'has_archive' => false,
+    'rewrite' => array('slug' => 'tutorials','with_front' => false),
+    'hierarchical' => true,
+    'supports' => array('title', 'author', 'comments', 'editor','page-attributes','thumbnail', 'excerpt', 'post-formats'),
+    'taxonomies' => array('category')
+  );
+
+  register_post_type( 'tutorials', $args);
+  add_post_type_support( 'tutorials', 'genesis-layouts' );
+}
+
+?>

--- a/lib/post_types/tutorials.php
+++ b/lib/post_types/tutorials.php
@@ -9,7 +9,7 @@ function create_tutorials_post_type() {
   $args = array(
     'labels' => $labels,
     'public' => true,
-    'has_archive' => true,
+    'has_archive' => false,
     'rewrite' => array('slug' => 'tutorials','with_front' => false),
     'hierarchical' => true,
     'supports' => array('title', 'author', 'comments', 'editor','page-attributes','thumbnail', 'excerpt', 'post-formats'),

--- a/lib/post_types/tutorials.php
+++ b/lib/post_types/tutorials.php
@@ -9,7 +9,7 @@ function create_tutorials_post_type() {
   $args = array(
     'labels' => $labels,
     'public' => true,
-    'has_archive' => false,
+    'has_archive' => true,
     'rewrite' => array('slug' => 'tutorials','with_front' => false),
     'hierarchical' => true,
     'supports' => array('title', 'author', 'comments', 'editor','page-attributes','thumbnail', 'excerpt', 'post-formats'),


### PR DESCRIPTION
Adds `Tutorials`:
![Screen Shot 2019-05-08 at 3 15 30 pm](https://user-images.githubusercontent.com/692868/57351144-2290c900-71a4-11e9-85a5-49fedc0d0376.png)

...which show up on the blog feed (can do other things later, e.g. custom Tutorials page): 
![Screen Shot 2019-05-08 at 3 14 50 pm](https://user-images.githubusercontent.com/692868/57351132-1ad12480-71a4-11e9-9b45-48298f6a3227.png)

...but link to their own URL: `/tutorials/how-to-set-up-double-opt-in-to-manage-user-consent/`
![Screen Shot 2019-05-08 at 3 15 48 pm](https://user-images.githubusercontent.com/692868/57351161-2cb2c780-71a4-11e9-80c8-de4de2297ebd.png)
