### PR TITLE
New demo form for marketing site pages

### DIFF
--- a/page-customer-engagement.php
+++ b/page-customer-engagement.php
@@ -21,7 +21,7 @@
       <div class="flex items-center justify-center intro-footer">
         <a class="btn btn-success btn-large md-right-margin-small" href="https://app.getvero.com/signup">Start a free trial</a>
 
-        <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="drawer_right" target="_blank">Talk to us</a> 
+        <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="popup" target="_blank">Talk to us</a> 
       </div>
     </div>
   </div>

--- a/page-customer-engagement.php
+++ b/page-customer-engagement.php
@@ -21,7 +21,7 @@
       <div class="flex items-center justify-center intro-footer">
         <a class="btn btn-success btn-large md-right-margin-small" href="https://app.getvero.com/signup">Start a free trial</a>
 
-        <a class="medium regular underline-link" id="demo-trigger" rel="leanModal" href="#demo">Talk to us</a>
+        <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="drawer_right" style="color:#267DDD;text-decoration:underline;font-size:17px;" target="_blank">Talk to us</a> 
       </div>
     </div>
   </div>

--- a/page-customer-engagement.php
+++ b/page-customer-engagement.php
@@ -21,7 +21,7 @@
       <div class="flex items-center justify-center intro-footer">
         <a class="btn btn-success btn-large md-right-margin-small" href="https://app.getvero.com/signup">Start a free trial</a>
 
-        <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="drawer_right" style="color:#267DDD;text-decoration:underline;font-size:17px;" target="_blank">Talk to us</a> 
+        <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="drawer_right" target="_blank">Talk to us</a> 
       </div>
     </div>
   </div>

--- a/page-data-management.php
+++ b/page-data-management.php
@@ -21,7 +21,7 @@
       <div class="flex items-center justify-center intro-footer">
         <a class="btn btn-success btn-large md-right-margin-small" href="https://app.getvero.com/signup">Start a free trial</a>
 
-        <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="drawer_right" target="_blank">Talk to us</a> 
+        <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="popup" target="_blank">Talk to us</a> 
       </div>
     </div>
   </div>

--- a/page-data-management.php
+++ b/page-data-management.php
@@ -21,7 +21,7 @@
       <div class="flex items-center justify-center intro-footer">
         <a class="btn btn-success btn-large md-right-margin-small" href="https://app.getvero.com/signup">Start a free trial</a>
 
-        <a class="medium regular underline-link" id="demo-trigger" rel="leanModal" href="#demo">Talk to us</a>
+        <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="drawer_right" style="color:#267DDD;text-decoration:underline;font-size:17px;" target="_blank">Talk to us</a> 
       </div>
     </div>
   </div>

--- a/page-data-management.php
+++ b/page-data-management.php
@@ -21,7 +21,7 @@
       <div class="flex items-center justify-center intro-footer">
         <a class="btn btn-success btn-large md-right-margin-small" href="https://app.getvero.com/signup">Start a free trial</a>
 
-        <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="drawer_right" style="color:#267DDD;text-decoration:underline;font-size:17px;" target="_blank">Talk to us</a> 
+        <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="drawer_right" target="_blank">Talk to us</a> 
       </div>
     </div>
   </div>

--- a/page-homepage.php
+++ b/page-homepage.php
@@ -16,7 +16,7 @@
         <div class="flex flex-wrap md-flex-nowrap justify-center md-justify-start items-center bottom-margin-large">
           <a class="btn btn-success btn-large hide smd-show smd-right-margin-smedium" href="https://app.getvero.com/signup">Start a free trial</a>
 
-          <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="drawer_right" target="_blank">Talk to us</a> 
+          <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="popup" target="_blank">Talk to us</a> 
         </div>
 
         <h2 class="micro regular faded bottom-margin-smedium">Trusted by leading brands</h2>

--- a/page-homepage.php
+++ b/page-homepage.php
@@ -16,7 +16,7 @@
         <div class="flex flex-wrap md-flex-nowrap justify-center md-justify-start items-center bottom-margin-large">
           <a class="btn btn-success btn-large hide smd-show smd-right-margin-smedium" href="https://app.getvero.com/signup">Start a free trial</a>
 
-          <a class="medium regular underline-link" id="demo-trigger" rel="leanModal" href="#demo">Talk to us</a>
+          <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="drawer_right" style="color:#267DDD;text-decoration:underline;font-size:17px;" target="_blank">Talk to us</a> 
         </div>
 
         <h2 class="micro regular faded bottom-margin-smedium">Trusted by leading brands</h2>

--- a/page-homepage.php
+++ b/page-homepage.php
@@ -16,7 +16,7 @@
         <div class="flex flex-wrap md-flex-nowrap justify-center md-justify-start items-center bottom-margin-large">
           <a class="btn btn-success btn-large hide smd-show smd-right-margin-smedium" href="https://app.getvero.com/signup">Start a free trial</a>
 
-          <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="drawer_right" style="color:#267DDD;text-decoration:underline;font-size:17px;" target="_blank">Talk to us</a> 
+          <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="drawer_right" target="_blank">Talk to us</a> 
         </div>
 
         <h2 class="micro regular faded bottom-margin-smedium">Trusted by leading brands</h2>

--- a/page-send-automated-messages.php
+++ b/page-send-automated-messages.php
@@ -21,7 +21,7 @@
       <div class="flex items-center justify-center intro-footer">
         <a class="btn btn-success btn-large md-right-margin-small" href="https://app.getvero.com/signup">Start a free trial</a>
 
-        <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="drawer_right" target="_blank">Talk to us</a> 
+        <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="popup" target="_blank">Talk to us</a> 
       </div>
     </div>
   </div>

--- a/page-send-automated-messages.php
+++ b/page-send-automated-messages.php
@@ -21,7 +21,7 @@
       <div class="flex items-center justify-center intro-footer">
         <a class="btn btn-success btn-large md-right-margin-small" href="https://app.getvero.com/signup">Start a free trial</a>
 
-        <a class="medium regular underline-link" id="demo-trigger" rel="leanModal" href="#demo">Talk to us</a>
+        <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="drawer_right" style="color:#267DDD;text-decoration:underline;font-size:17px;" target="_blank">Talk to us</a> 
       </div>
     </div>
   </div>

--- a/page-send-automated-messages.php
+++ b/page-send-automated-messages.php
@@ -21,7 +21,7 @@
       <div class="flex items-center justify-center intro-footer">
         <a class="btn btn-success btn-large md-right-margin-small" href="https://app.getvero.com/signup">Start a free trial</a>
 
-        <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="drawer_right" style="color:#267DDD;text-decoration:underline;font-size:17px;" target="_blank">Talk to us</a> 
+        <a class="medium regular underline-link typeform-share link" id="demo-trigger" href="https://getvero.typeform.com/to/d9wZ4V" data-mode="drawer_right" target="_blank">Talk to us</a> 
       </div>
     </div>
   </div>


### PR DESCRIPTION
Replaces simple form for people who want a demo – this automatically has a workflow that adds people to Pipedrive for us.

Does this: 
![Screen Recording 2019-07-05 at 03 37 pm](https://user-images.githubusercontent.com/692868/60700427-399d2e80-9f3b-11e9-9d94-a6ca60406858.gif)

